### PR TITLE
fix(biome.json): added package.json to biome format ignore

### DIFF
--- a/.changeset/moody-books-sink.md
+++ b/.changeset/moody-books-sink.md
@@ -1,0 +1,5 @@
+---
+"node-utils-template": patch
+---
+
+Added package.json to biome formatter ignore due to know flakiness issue: inconsistent between lint:fix and lint (ci)

--- a/biome.json
+++ b/biome.json
@@ -13,6 +13,7 @@
   },
   "formatter": {
     "enabled": true,
+    "ignore": ["package.json"],
     "indentStyle": "space",
     "indentWidth": 2
   },


### PR DESCRIPTION
package.json arrays are formatted differently between biome check --fix and biome ci; issue seems to be scoped to package.json only, and is flakey